### PR TITLE
fix: Improve MUI performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "dev": "vite-react-ssg dev",
-    "build": "tsx scripts/generate-sitemap.ts && tsc && vite-react-ssg build",
+    "build": "tsx scripts/generate-sitemap.ts && tsc --noEmit && vite-react-ssg build",
     "preview": "vite preview",
     "prettify": "prettier -w --log-level=silent src/",
     "lint": "eslint --fix ./src/",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { CssBaseline } from '@mui/material';
+import CssBaseline from '@mui/material/CssBaseline';
 
 import { JsonLd, SEOHead } from '@/components/SEO';
 import { MainLayout } from '@/ui/MainLayout/MainLayout';

--- a/src/components/FooterComponent/FooterComponent.tsx
+++ b/src/components/FooterComponent/FooterComponent.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from 'react-i18next';
 
 import CopyrightIcon from '@mui/icons-material/Copyright';
-import { Divider, Link, Stack, Typography } from '@mui/material';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 export default function FooterComponent() {
   const { t } = useTranslation();

--- a/src/components/HeaderComponent/HeaderComponent.tsx
+++ b/src/components/HeaderComponent/HeaderComponent.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-import { Stack, Typography } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 export function HeaderComponent() {
   const { t } = useTranslation();

--- a/src/components/InputComponent/InputComponent.tsx
+++ b/src/components/InputComponent/InputComponent.tsx
@@ -2,16 +2,14 @@ import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  Box,
-  Button,
-  FormHelperText,
-  InputAdornment,
-  InputLabel,
-  OutlinedInput,
-  Stack,
-  Typography
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormHelperText from '@mui/material/FormHelperText';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputLabel from '@mui/material/InputLabel';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { z } from 'zod';
 
 import { formSchema } from '@/validation/formSchema';

--- a/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,7 +1,11 @@
 import { useTranslation } from 'react-i18next';
 
-import { FormControl, MenuItem, Select, SelectChangeEvent, Tooltip } from '@mui/material';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
 
 export function LanguageSwitcher() {
   const { i18n, t } = useTranslation();

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
-import { CircularProgress, CircularProgressProps } from '@mui/material';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
+import type { CircularProgressProps } from '@mui/material/CircularProgress';
+import CircularProgress from '@mui/material/CircularProgress';
 
 export type LoadingSpinnerProps = CircularProgressProps & {
   position?: 'right' | 'left' | 'center';

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,8 @@
 import ElectricBoltIcon from '@mui/icons-material/ElectricBolt';
-import { AppBar, Box, Stack, Typography } from '@mui/material';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import { LanguageSwitcher } from '@/components/LanguageSwitcher/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle/ThemeToggle';

--- a/src/components/ResultComponent/ResultComponent.tsx
+++ b/src/components/ResultComponent/ResultComponent.tsx
@@ -1,16 +1,14 @@
 import { useTranslation } from 'react-i18next';
 
-import {
-  Box,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
 
 interface InputComponentProps {
   hourlyResult: number | undefined;

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -2,7 +2,8 @@ import { useTranslation } from 'react-i18next';
 
 import Brightness4Icon from '@mui/icons-material/Brightness4'; // Dark mode icon
 import Brightness7Icon from '@mui/icons-material/Brightness7'; // Light mode icon
-import { IconButton, Tooltip } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import { useTheme } from '@/ui/theme/ThemeContext';
 

--- a/src/test/setupTests.tsx
+++ b/src/test/setupTests.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { initReactI18next } from 'react-i18next';
 import { I18nextProvider } from 'react-i18next';
 
-import { ThemeProvider } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import i18n from 'i18next';
 

--- a/src/ui/CalculatorLayout/CalculatorLayout.tsx
+++ b/src/ui/CalculatorLayout/CalculatorLayout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
-import { Container, Stack } from '@mui/material';
+import Container from '@mui/material/Container';
+import Stack from '@mui/material/Stack';
 
 import { InputComponent } from '@/components/InputComponent/InputComponent';
 import { ResultComponent } from '@/components/ResultComponent/ResultComponent';

--- a/src/ui/MainLayout/MainLayout.tsx
+++ b/src/ui/MainLayout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 
 import { CalculatorLayout } from '../CalculatorLayout/CalculatorLayout';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "./dist/",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": true,
     "target": "ES2020",
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,16 +26,12 @@ export default defineConfig(({ mode }) => {
       port: 3000
     },
 
+    esbuild: isProd ? { drop: ['console', 'debugger'] } : {},
+
     build: {
       outDir: 'dist',
       sourcemap: false,
-      minify: 'terser',
-      terserOptions: {
-        compress: {
-          drop_console: isProd,
-          drop_debugger: isProd
-        }
-      },
+      minify: 'esbuild',
       rollupOptions: {
         output: {
           manualChunks: (id) => {


### PR DESCRIPTION
### What's new

No new features here...

### What's fixed

- Use Terser minifier instead of esbuild
- Removed redundant `tsc` full emit in build script
- Remove barrel imports from `@mui/material`
- Remove unnecessary `sourceMap: true` in tsconfig

### How to test

- `pnpm verify`

### Breaking changes

No breaking changes here...
